### PR TITLE
Fixes crash when using a password to connect to an IRC network

### DIFF
--- a/lib/irclib/ircbot.py
+++ b/lib/irclib/ircbot.py
@@ -92,7 +92,7 @@ class SingleServerIRCBot(SimpleIRCClient):
         if len(self.server_list[0]) > 2:
             password = self.server_list[0][2]
         try:
-            print("Connecting to %s:%d" % self.server_list[0])
+            print("Connecting to %s:%d" % self.server_list[0][:2])
             self.connect(self.server_list[0][0],
                          self.server_list[0][1],
                          self._nickname,


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "../lib/pyborg/pyborg-irc.py", line 727, in <module>
    bot.our_start()
  File "../lib/pyborg/pyborg-irc.py", line 179, in our_start
    self.start()
  File "/home/user/PyBorg/lib/pyborg/ircbot.py", line 252, in start
    self._connect()
  File "/home/user/PyBorg/lib/pyborg/ircbot.py", line 95, in _connect
    print("Connecting to %s:%d" % self.server_list[0])
```